### PR TITLE
Demotivator

### DIFF
--- a/draft-ietf-tls-rfc4492bis.xml
+++ b/draft-ietf-tls-rfc4492bis.xml
@@ -68,23 +68,6 @@
   <middle>
     <!-- ====================================================================== -->
     <section anchor="introduction" title="Introduction">
-      <t> Elliptic Curve Cryptography (ECC) has emerged as an attractive public-key cryptosystem, in particular for
-        mobile (i.e., wireless) environments.  Compared to currently prevalent cryptosystems such as RSA, ECC offers
-        equivalent security with smaller key sizes.  This is illustrated in the following table, based on
-        <xref target="Lenstra_Verheul"/>, which gives approximate comparable key sizes for symmetric- and
-        asymmetric-key cryptosystems based on the best-known algorithms for attacking them.</t>
-      <texttable anchor="tbl1" title="Comparable Key Sizes (in bits)">
-        <ttcol align="center">Symmetric</ttcol>
-        <ttcol align="center">ECC</ttcol>
-        <ttcol align="center">DH/DSA/RSA</ttcol>
-        <c>80</c><c>&gt;=158</c><c>1024</c>
-        <c>112</c><c>&gt;=221</c><c>2048</c>
-        <c>128</c><c>&gt;=252</c><c>3072</c>
-        <c>192</c><c>&gt;=379</c><c>7680</c>
-        <c>256</c><c>&gt;=506</c><c>15360</c>
-      </texttable>
-      <t> Smaller key sizes result in savings for power, memory, bandwidth, and computational cost that make ECC
-        especially attractive for constrained environments.</t>
       <t> This document describes additions to TLS to support ECC, applicable to TLS versions 1.0
         <xref target="RFC2246"/>, 1.1 <xref target="RFC4346"/>, and 1.2 <xref target="RFC5246"/>.  The use of ECC in
         TLS 1.3 is defined in <xref target="I-D.ietf-tls-tls13" />, and is explicitly out of scope for this document.


### PR DESCRIPTION
Removed two paragraphs and a table full of motivation about why ECC is great. In 2016 this is no longer needed. ECC is already mainstream.