### PR TITLE
Prepending 'TLS' to the registry names

### DIFF
--- a/draft-ietf-tls-rfc4492bis.xml
+++ b/draft-ietf-tls-rfc4492bis.xml
@@ -832,7 +832,7 @@
         <t> Supported Groups <xref target="ch_extensions"/></t>
         <t> ECPointFormat <xref target="ch_extensions"/></t>
         <t> ECCurveType <xref target="ske"/></t></list></t>
-      <t> IANA is requested to prepend "TLS" to the names of the previouew three registries.</t>
+      <t> IANA is requested to prepend "TLS" to the names of the previous three registries.</t>
       <t> For each name space, this document defines the initial value assignments and defines a range of 256 values
         (NamedCurve) or eight values (ECPointFormat and ECCurveType) reserved for Private Use.  The policy for any additional
         assignments is "Specification Required". The previous version of this document required IETF review.</t>

--- a/draft-ietf-tls-rfc4492bis.xml
+++ b/draft-ietf-tls-rfc4492bis.xml
@@ -832,6 +832,7 @@
         <t> Supported Groups <xref target="ch_extensions"/></t>
         <t> ECPointFormat <xref target="ch_extensions"/></t>
         <t> ECCurveType <xref target="ske"/></t></list></t>
+      <t> IANA is requested to prepend "TLS" to the names of the previouew three registries.</t>
       <t> For each name space, this document defines the initial value assignments and defines a range of 256 values
         (NamedCurve) or eight values (ECPointFormat and ECCurveType) reserved for Private Use.  The policy for any additional
         assignments is "Specification Required". The previous version of this document required IETF review.</t>
@@ -875,7 +876,8 @@
       <t> Changes from RFC 4492 to draft-nir-tls-rfc4492bis-00:<list style="symbols">
         <t> Added TLS 1.2 to references.</t>
         <t> Moved RFC 4492 authors to acknowledgements.</t>
-        <t> Removed list of required reading for ECC.</t></list></t>
+        <t> Removed list of required reading for ECC.</t>
+        <t> Prepended "TLS" to the names of the three registries defined in the IANA Considerations section.</list></t>
     </section>
 
     <!-- ====================================================================== -->


### PR DESCRIPTION
if both draft-ietf-tls-iana-registry-updates and this draft add TLS to the registry names then all the registry will have a consistent naming scheme.
