### PR TITLE
Fix inline reference to table

### DIFF
--- a/draft-ietf-tls-rfc4492bis.xml
+++ b/draft-ietf-tls-rfc4492bis.xml
@@ -401,7 +401,7 @@
           table shows the server certificate type appropriate for each key exchange algorithm.  ECC public keys MUST
           be encoded in certificates as described in <xref target="eccerts"/>.</t>
         <t> NOTE: The server's Certificate message is capable of carrying a chain of certificates.  The restrictions
-          mentioned in Table 3 apply only to the server's certificate (first in the chain).</t>
+          mentioned in <xref target="tbl3"/> apply only to the server's certificate (first in the chain).</t>
         <texttable anchor="tbl3" title="Server Certificate Types">
         <ttcol align="left">Algorithm</ttcol>
         <ttcol align="left">Server Certificate Type</ttcol>


### PR DESCRIPTION
This is the second table even if the target is called "tbl3".
___
> NOTE: The server's Certificate message is capable of carrying a chain
>  of certificates.  The restrictions mentioned in Table ~~3~~**2** apply only to
>  the server's certificate (first in the chain).
>
>     +-------------+-----------------------------------------------------+
>     | Algorithm   | Server Certificate Type                             |
>     +-------------+-----------------------------------------------------+
>     | ECDHE_ECDSA | Certificate MUST contain an ECDSA- or EdDSA-capable |
>     |             | public key.                                         |
>     | ECDHE_RSA   | Certificate MUST contain an RSA public key.         |
>     +-------------+-----------------------------------------------------+
>
>                      Table 2: Server Certificate Types